### PR TITLE
Codechain options

### DIFF
--- a/command/publish.go
+++ b/command/publish.go
@@ -22,7 +22,7 @@ import (
 	"github.com/frankbraun/codechain/util/terminal"
 )
 
-func publish(c *hashchain.HashChain, secKeyFile string, dryRun, useGit bool) error {
+func publish(c *hashchain.HashChain, secKeyFile string, dryRun, useGit, yesPrompt bool) error {
 	var (
 		secKey *[64]byte
 		err    error
@@ -100,8 +100,12 @@ func publish(c *hashchain.HashChain, secKeyFile string, dryRun, useGit bool) err
 	}
 
 	// confirm patch
-	if err := terminal.Confirm("publish patch?"); err != nil {
-		return err
+	if yesPrompt {
+		fmt.Println("patch published automatically (-y was used).")
+	} else {
+		if err := terminal.Confirm("publish patch?"); err != nil {
+			return err
+		}
 	}
 
 	// read comment
@@ -149,6 +153,7 @@ func Publish(argv0 string, args ...string) error {
 	useGit := fs.Bool("git", true, "Use git-diff to show diffs")
 	secKey := fs.String("s", "", "Secret key file")
 	verbose := fs.Bool("v", false, "Be verbose")
+	yesPrompt := fs.Bool("y", false, "Automatic yes to prompts, use with care!")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -184,7 +189,7 @@ func Publish(argv0 string, args ...string) error {
 	})
 	// run publish
 	go func() {
-		if err := publish(c, *secKey, *dryRun, *useGit); err != nil {
+		if err := publish(c, *secKey, *dryRun, *useGit, *yesPrompt); err != nil {
 			interrupt.ShutdownChannel <- err
 			return
 		}

--- a/internal/def/def.go
+++ b/internal/def/def.go
@@ -2,11 +2,31 @@
 package def
 
 import (
+	"os"
 	"path/filepath"
 )
 
-// CodechainDir is the default directory used for Codechain related files.
-const CodechainDir = ".codechain"
+// DefaultCodechainDir is the default directory used for Codechain related files.
+// Can be overwritten with the environment variable CODECHAIN_DIR.
+const DefaultCodechainDir = ".codechain"
+
+// CodechainDir is the directory used for Codechain releated files. If not set
+// with the environment variable CODECHAIN_DIR, DefaultCodechainDir is used.
+// If CODECHAIN_DIR is used, the environment variable CODECHAIN_EXCLUDE can be
+// used to exclude a second Codechain directory from all Codechain commands.
+var CodechainDir = DefaultCodechainDir
+
+func init() {
+	dir := os.Getenv("CODECHAIN_DIR")
+	if dir != "" {
+		CodechainDir = dir
+		ExcludePaths = append(ExcludePaths, dir)
+	}
+	exclude := os.Getenv("CODECHAIN_EXCLUDE")
+	if exclude != "" {
+		ExcludePaths = append(ExcludePaths, exclude)
+	}
+}
 
 // SecretsSubDir is the default subdirectory of a tool's home directory used
 // to store secret key files
@@ -20,7 +40,7 @@ const CodechainURLName = "_codechain-url."
 
 // ExcludePaths is the default list of paths not considered by Codechain.
 var ExcludePaths = []string{
-	CodechainDir,
+	DefaultCodechainDir,
 	".git",
 	".gitignore",
 	".travis.yml",


### PR DESCRIPTION
I added two new options to `codechain publish` and the environment variables `CODECHAIN_DIR` and `CODECHAIN_EXCLUDE` to be able to use codechain in a script and with multiple .codechain directories.