### PR TITLE
setting $CODECHAIN_DIR should not effect `secpkg`

### DIFF
--- a/secpkg/checkupdate.go
+++ b/secpkg/checkupdate.go
@@ -109,7 +109,7 @@ func checkUpdate(ctx context.Context, visited map[string]bool, name string) (boo
 	log.Println("7. check if HEAD is contained in hashchain")
 	if !needsUpdate {
 		srcDir := filepath.Join(pkgDir, "src")
-		c, err := hashchain.ReadFile(filepath.Join(srcDir, def.HashchainFile))
+		c, err := hashchain.ReadFile(filepath.Join(srcDir, def.UnoverwriteableHashchainFile))
 		if err != nil {
 			return false, err
 		}

--- a/secpkg/ensure.go
+++ b/secpkg/ensure.go
@@ -90,7 +90,7 @@ func ensure(
 			}
 			// make sure HEAD of .secpkg is actually contained in hash chain
 			// (that is, we have updated the correct package).
-			hashchainFile := filepath.Join(pkgDir, "src", def.HashchainFile)
+			hashchainFile := filepath.Join(pkgDir, "src", def.UnoverwriteableHashchainFile)
 			c, err := hashchain.ReadFile(hashchainFile)
 			if err != nil {
 				return false, err

--- a/secpkg/install.go
+++ b/secpkg/install.go
@@ -109,20 +109,20 @@ func (pkg *Package) install(ctx context.Context, visited map[string]bool) error 
 		if err != nil {
 			return err
 		}
-		err = archive.ApplyEncryptedFile(def.HashchainFile, def.PatchDir,
+		err = archive.ApplyEncryptedFile(def.UnoverwriteableHashchainFile, def.PatchDir,
 			distFile, &head, key)
 		if err != nil {
 			os.RemoveAll(pkgDir)
 			return err
 		}
 	} else {
-		err = archive.ApplyFile(def.HashchainFile, def.PatchDir, distFile, &head)
+		err = archive.ApplyFile(def.UnoverwriteableHashchainFile, def.PatchDir, distFile, &head)
 		if err != nil {
 			os.RemoveAll(pkgDir)
 			return err
 		}
 	}
-	c, err := hashchain.ReadFile(def.HashchainFile)
+	c, err := hashchain.ReadFile(def.UnoverwriteableHashchainFile)
 	if err != nil {
 		os.RemoveAll(pkgDir)
 		return err

--- a/secpkg/update.go
+++ b/secpkg/update.go
@@ -104,7 +104,7 @@ func update(ctx context.Context, visited map[string]bool, name string) (bool, er
 	//    This can happend if we checked for updates.
 	srcDir := filepath.Join(pkgDir, "src")
 	if skipBuild {
-		c, err := hashchain.ReadFile(filepath.Join(srcDir, def.HashchainFile))
+		c, err := hashchain.ReadFile(filepath.Join(srcDir, def.UnoverwriteableHashchainFile))
 		if err != nil {
 			return false, err
 		}
@@ -148,18 +148,18 @@ func update(ctx context.Context, visited map[string]bool, name string) (bool, er
 			if err != nil {
 				return false, err
 			}
-			err = archive.ApplyEncryptedFile(def.HashchainFile, def.PatchDir,
+			err = archive.ApplyEncryptedFile(def.UnoverwriteableHashchainFile, def.PatchDir,
 				distFile, &head, key)
 			if err != nil {
 				return false, err
 			}
 		} else {
-			err = archive.ApplyFile(def.HashchainFile, def.PatchDir, distFile, &head)
+			err = archive.ApplyFile(def.UnoverwriteableHashchainFile, def.PatchDir, distFile, &head)
 			if err != nil {
 				return false, err
 			}
 		}
-		c, err := hashchain.ReadFile(def.HashchainFile)
+		c, err := hashchain.ReadFile(def.UnoverwriteableHashchainFile)
 		if err != nil {
 			return false, err
 		}

--- a/util/def/def.go
+++ b/util/def/def.go
@@ -28,6 +28,7 @@ func init() {
 	}
 	HashchainFile = filepath.Join(CodechainDir, "hashchain")
 	PatchDir = filepath.Join(CodechainDir, "patches")
+	UnoverwriteableHashchainFile = filepath.Join(DefaultCodechainDir, "hashchain")
 }
 
 // SecretsSubDir is the default subdirectory of a tool's home directory used
@@ -54,6 +55,10 @@ var ExcludePaths = []string{
 
 // HashchainFile is the default name of the hashchain file.
 var HashchainFile string
+
+// UnoverwriteableHashchainFile is the unoverwriteable default name of the
+// hashchain file. Setting CODECHAIN_DIR has no effect on it.
+var UnoverwriteableHashchainFile string
 
 // PatchDir is the default name of the patch file directory.
 var PatchDir string


### PR DESCRIPTION
Setting $CODECHAIN_DIR effects secpkg.UpToDate and leads to a failure of
the update check.
This patch introduces def.UnoverwriteableHashchainFile and uses it in
the secpkg package in order to fix problem.