### PR TITLE
archives should always use the default .codechain

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -20,8 +20,8 @@ import (
 )
 
 var (
-	globalHashchainFile = path.Join(def.CodechainDir, "hashchain")
-	globalPatchDir      = path.Join(def.CodechainDir, "patches")
+	globalHashchainFile = path.Join(def.DefaultCodechainDir, "hashchain")
+	globalPatchDir      = path.Join(def.DefaultCodechainDir, "patches")
 )
 
 // Create a new archive for the given hash chain and write it to w.

--- a/ssot/command/createpkg.go
+++ b/ssot/command/createpkg.go
@@ -96,11 +96,9 @@ func createPkg(
 	}
 
 	// 3. Test build (see TestBuild specification).
-	fmt.Println("call testBuild()")
 	if err := testBuild(); err != nil {
 		return err
 	}
-	fmt.Println("done testBuild()")
 
 	// Create .secpkg file
 	exists, err = file.Exists(secpkgFile)


### PR DESCRIPTION
Otherwise extracting archives created with CODECHAIN_DIR set doesn't
work.

Also remove some debugging code.